### PR TITLE
Jupyterlab RTC Hub Settings 0.1.2

### DIFF
--- a/jupyterlab_rtc_hub_settings/package.json
+++ b/jupyterlab_rtc_hub_settings/package.json
@@ -45,13 +45,13 @@
     "watch:labextension": "jupyter labextension watch ."
   },
   "dependencies": {
-    "@jupyterlab/application": "^3.1.0",
-    "@jupyterlab/coreutils": "^5.1.0",
-    "@jupyterlab/services": "^6.1.0"
+    "@jupyterlab/application": "^3.6.4",
+    "@jupyterlab/coreutils": "^5.6.5",
+    "@jupyterlab/services": "^6.6.5"
 
   },
   "devDependencies": {
-    "@jupyterlab/builder": "^3.1.0",
+    "@jupyterlab/builder": "^3.6.5",
     "@typescript-eslint/eslint-plugin": "^4.8.1",
     "@typescript-eslint/parser": "^4.8.1",
     "eslint": "^7.14.0",

--- a/jupyterlab_rtc_hub_settings/package.json
+++ b/jupyterlab_rtc_hub_settings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jupyterlab_rtc_hub_settings",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "A JupyterLab extension to manage real time collaboration settings on JupyterHub",
   "keywords": [
     "jupyter",

--- a/jupyterlab_rtc_hub_settings/package.json
+++ b/jupyterlab_rtc_hub_settings/package.json
@@ -48,7 +48,6 @@
     "@jupyterlab/application": "^3.6.4",
     "@jupyterlab/coreutils": "^5.6.5",
     "@jupyterlab/services": "^6.6.5"
-
   },
   "devDependencies": {
     "@jupyterlab/builder": "^3.6.5",
@@ -56,8 +55,8 @@
     "@typescript-eslint/parser": "^4.8.1",
     "eslint": "^7.14.0",
     "eslint-config-prettier": "^6.15.0",
-    "eslint-plugin-prettier": "^3.1.4", 
-    "mkdirp": "^1.0.3", 
+    "eslint-plugin-prettier": "^3.1.4",
+    "mkdirp": "^1.0.3",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.1.1",
     "rimraf": "^3.0.2",
@@ -68,17 +67,17 @@
     "style/index.js"
   ],
   "styleModule": "style/index.js",
-  "jupyterlab": { 
+  "jupyterlab": {
     "discovery": {
-        "server": {
-          "managers": [
-            "pip"
-          ],
-          "base": {
-            "name": "jupyterlab_rtc_hub_settings"
-          }
+      "server": {
+        "managers": [
+          "pip"
+        ],
+        "base": {
+          "name": "jupyterlab_rtc_hub_settings"
         }
-    }, 
+      }
+    },
     "extension": true,
     "outputDir": "jupyterlab_rtc_hub_settings/labextension"
   },

--- a/jupyterlab_rtc_hub_settings/pyproject.toml
+++ b/jupyterlab_rtc_hub_settings/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["jupyter_packaging~=0.10,<2", "jupyterlab~=3.1"]
+requires = ["jupyter_packaging~=0.10,<2", "jupyterlab~=3.6"]
 build-backend = "jupyter_packaging.build_api"
 
 [tool.jupyter-packaging.options]

--- a/jupyterlab_rtc_hub_settings/setup.py
+++ b/jupyterlab_rtc_hub_settings/setup.py
@@ -49,7 +49,7 @@ setup_args = dict(
     long_description_content_type="text/markdown",
     packages=setuptools.find_packages(),
     install_requires=[
-        "jupyter_server>=1.6,<2",
+        "jupyter_server>=1.6,<3",
         "escapism"
     ],
     zip_safe=False,

--- a/jupyterlab_rtc_hub_settings/tsconfig.json
+++ b/jupyterlab_rtc_hub_settings/tsconfig.json
@@ -17,7 +17,7 @@
     "rootDir": "src",
     "strict": true,
     "strictNullChecks": true,
-    "target": "es2017",
+    "target": "es2018",
     "types": []
   },
   "include": ["src/*"]


### PR DESCRIPTION
Update to support JupyterLab >=3.6, <4 and Jupyter Server 2.0+.

This change is already live on PyPI and tested in Notebooks Hub