### PR TITLE
Fix/rtc mentions of jupyterlab 4

### DIFF
--- a/.github/workflows/jupyterlab-rtc-hub-settings-build.yml
+++ b/.github/workflows/jupyterlab-rtc-hub-settings-build.yml
@@ -51,7 +51,7 @@ jobs:
           yarn-
     
     - name: Install dependencies
-      run: python -m pip install -U jupyterlab~=3.0 check-manifest
+      run: python -m pip install -U jupyterlab~=4.0 check-manifest
 
     - name: Build the extension
       run: |

--- a/jupyterlab_rtc_hub_settings/README.md
+++ b/jupyterlab_rtc_hub_settings/README.md
@@ -34,7 +34,7 @@ The example JupyterHub configuration will be provided soon.
 
 ## Requirements
 
-* JupyterLab >= 3.0
+* JupyterLab >= 4.0
 
 
 ## Install

--- a/jupyterlab_rtc_hub_settings/pyproject.toml
+++ b/jupyterlab_rtc_hub_settings/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["jupyter_packaging~=0.10,<2", "jupyterlab~=3.6"]
+requires = ["jupyter_packaging~=0.12,<2", "jupyterlab~=4.0"]
 build-backend = "jupyter_packaging.build_api"
 
 [tool.jupyter-packaging.options]


### PR DESCRIPTION
Clean up remaining mentions of JupyterLab 3.x in RTC extension