### PR TITLE
updated polus-render npm package to 0.2.6

### DIFF
--- a/jupyterlab_polus_render/examples/intro.ipynb
+++ b/jupyterlab_polus_render/examples/intro.ipynb
@@ -19,7 +19,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c88a47c3cb7a404686439b66c9058f07",
+       "model_id": "43ab34e5e4514b6faf1a94ed1c55fef8",
        "version_major": 2,
        "version_minor": 0
       },
@@ -45,12 +45,12 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "eff869603a3241b3bb952a72ca8c762d",
+       "model_id": "25eddcf31f0944d9ae5aaffb7d78fddb",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
-       "Render(imagePath='/Users/akshat.saini/Documents/pj/forks/jupyterlab-extensions/jupyterlab_polus_render/images/…"
+       "Render(imagePath='/Users/sainia2/Documents/pj/forks/jupyterlab-extensions/jupyterlab_polus_render/examples/../…"
       ]
      },
      "execution_count": 3,
@@ -61,6 +61,14 @@
    "source": [
     "Render(imagePath = '../images/LuCa-7color_3x3component_data.ome.tif')"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "72cb2f13-5c3b-4b36-a662-2c5bcbe633bb",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -79,7 +87,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.13"
+   "version": "3.10.14"
   }
  },
  "nbformat": 4,

--- a/jupyterlab_polus_render/package.json
+++ b/jupyterlab_polus_render/package.json
@@ -50,7 +50,7 @@
   },
   "dependencies": {
     "@jupyter-widgets/base": "^1.1.10 || ^2 || ^3 || ^4 || ^5 || ^6",
-    "@labshare/polus-render": "^0.1.4-test",
+    "@labshare/polus-render": "0.2.6",
     "@material-ui/core": "^4.11.0",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "^4.0.0-alpha.56",

--- a/jupyterlab_polus_render/src/widget.ts
+++ b/jupyterlab_polus_render/src/widget.ts
@@ -78,12 +78,7 @@ export class RenderView extends DOMWidgetView {
 
     this.el.innerHTML = `
     <div style="width:100%;height:900px">
-    <div style="position: absolute; z-index: 100; right: 0">
-              <image-menu-web-component></image-menu-web-component>
-              <overlay-menu-web-component></overlay-menu-web-component>
-            </div>
-            <viv-viewer-web-component-wrapper></viv-viewer-web-component-wrapper>
-            </div>
+    <polus-render></polus-render>
     `;
   }
 }

--- a/jupyterlab_polus_render/yarn.lock
+++ b/jupyterlab_polus_render/yarn.lock
@@ -2080,10 +2080,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@labshare/polus-render@npm:^0.1.4-test":
-  version: 0.1.4-test
-  resolution: "@labshare/polus-render@npm:0.1.4-test"
-  checksum: 1359cf608903479c9543731647b4cd09398362404fa645e4da2234a150d190420f50011cba8de23118e440414260f2676b0870d61415dc3773caf30748a10bdf
+"@labshare/polus-render@npm:0.2.6":
+  version: 0.2.6
+  resolution: "@labshare/polus-render@npm:0.2.6"
+  checksum: a354000c898ead8e60aeedca7f7bbef1619c8799e928069a86f304da1bf925425769b6319d93be98396f473ecf3bde80edcdc0d540d39caf370a13336d5f51ed
   languageName: node
   linkType: hard
 
@@ -7354,7 +7354,7 @@ __metadata:
     "@jupyter-widgets/base": ^1.1.10 || ^2 || ^3 || ^4 || ^5 || ^6
     "@jupyter-widgets/base-manager": ^1.0.7
     "@jupyterlab/builder": ^4.0.11
-    "@labshare/polus-render": ^0.1.4-test
+    "@labshare/polus-render": 0.2.6
     "@lumino/application": ^2.3.0
     "@lumino/widgets": ^2.3.1
     "@material-ui/core": ^4.11.0


### PR DESCRIPTION
npm package for Polus-Render has been updated to v0.2.6 with simplified integration. 

Includes below change in package.json
`"@labshare/polus-render": "0.2.6"`

Works using: 
`<polus-render></polus-render>`

The old way still works with the new version. 